### PR TITLE
Fixed crash with arg type 14, and support target class filter

### DIFF
--- a/Source/Core/Config/ArgumentInfo.cs
+++ b/Source/Core/Config/ArgumentInfo.cs
@@ -237,7 +237,7 @@ namespace CodeImp.DoomBuilder.Config
 
 		//mxd. Constructor for an argument info defined in DECORATE
 		internal ArgumentInfo(string actorname, string argtitle, string tooltip, string renderstyle, string rendercolor,
-			string minrange, string minrangecolor, string maxrange, string maxrangecolor,
+			string minrange, string minrangecolor, string maxrange, string maxrangecolor, string targetclasses,
 			int type, int defaultvalue, string enumstr, IDictionary<string, EnumList> enums)
 		{
 			this.used = true;
@@ -303,6 +303,17 @@ namespace CodeImp.DoomBuilder.Config
 						this.tooltip += "Minimum: " + this.minrange;
 					else
 						this.tooltip += "Maximum: " + this.maxrange;
+				}
+			}
+
+			//Check for TargetClass
+			this.targetclasses = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+			if(type == (int)UniversalType.ThingTag)
+			{
+				if(!string.IsNullOrEmpty(targetclasses))
+				{
+					foreach(string tclass in targetclasses.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries)) 
+						this.targetclasses.Add(tclass.Trim());
 				}
 			}
 

--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -479,6 +479,7 @@ namespace CodeImp.DoomBuilder.Config
 				string argtitle = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i));
 				string argtooltip = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "tooltip").Replace("\\n", Environment.NewLine));
 				int argtype = actor.GetPropertyValueInt("$arg" + i + "type", 0);
+				string targetclasses = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "targetclasses"));
 				int defaultvalue = actor.GetPropertyValueInt("$arg" + i + "default", 0);
 				string argenum = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "enum"));
 				string argrenderstyle = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "renderstyle"));
@@ -497,7 +498,7 @@ namespace CodeImp.DoomBuilder.Config
 				}
 				
 				args[i] = new ArgumentInfo(title, argtitle, argtooltip, argrenderstyle, argrendercolor, 
-					minrange, minrangecolor, maxrange, maxrangecolor, 
+					minrange, minrangecolor, maxrange, maxrangecolor, targetclasses,
 					argtype, defaultvalue, argenum, General.Map.Config.Enums);
 			}
 


### PR DESCRIPTION
If you configure an argument as type 14 in DECORATE, which is the thing type, a crash will occur when opening the edit panel.

This occurs because the target classes array is not initialized for decorate actors, but it is for configuration actors.

To resolve this, I just simply implemented the missing target class functionality for decorate actors, which allows decorate actors to access the filter for this type.

Sample Decorate:
```
ACTOR CRASHME 25111 {
	//$Title "CRASH ME"
	//$Sprite "internal:action"
	//$Arg0 "THE CRASH"
	//$Arg0Type 14
	//$Arg0TargetClasses "InterpolationPoint,PatrolPoint"

	States {
		Spawn:
			TNT1 A 1
			Stop
	}
}
```