### PR TITLE
Improve MakeDoor form - options for line special and tag

### DIFF
--- a/Source/Plugins/BuilderModes/General/BuilderPlug.cs
+++ b/Source/Plugins/BuilderModes/General/BuilderPlug.cs
@@ -66,13 +66,17 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			public readonly string TrackTexture;
 			public readonly string CeilingTexture;
 			public readonly bool ResetOffsets;
+			public readonly bool ApplyActionSpecials;
+			public readonly bool ApplyTag;
 
-			public MakeDoorSettings(string doortexture, string tracktexture, string ceilingtexture, bool resetoffsets)
+			public MakeDoorSettings(string doortexture, string tracktexture, string ceilingtexture, bool resetoffsets, bool applyactionspecials, bool applytag)
 			{
 				DoorTexture = doortexture;
 				TrackTexture = tracktexture;
 				CeilingTexture = ceilingtexture;
 				ResetOffsets = resetoffsets;
+				ApplyActionSpecials = applyactionspecials;
+				ApplyTag = applytag;
 			}
 		}
 
@@ -466,7 +470,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			//mxd
 			General.Interface.AddDocker(drawingOverridesDocker);
 			drawingOverridesPanel.Setup();
-			MakeDoor = new MakeDoorSettings(General.Map.Config.MakeDoorDoor, General.Map.Config.MakeDoorTrack, General.Map.Config.MakeDoorCeiling, MakeDoor.ResetOffsets);
+			MakeDoor = new MakeDoorSettings(General.Map.Config.MakeDoorDoor, General.Map.Config.MakeDoorTrack, General.Map.Config.MakeDoorCeiling, MakeDoor.ResetOffsets, MakeDoor.ApplyActionSpecials, MakeDoor.ApplyTag);
 			ResetCopyProperties();
 		}
 		
@@ -481,7 +485,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Interface.AddDocker(drawingOverridesDocker);
 			drawingOverridesPanel.Setup();
 			General.Map.Renderer2D.UpdateExtraFloorFlag();
-			MakeDoor = new MakeDoorSettings(General.Map.Config.MakeDoorDoor, General.Map.Config.MakeDoorTrack, General.Map.Config.MakeDoorCeiling, MakeDoor.ResetOffsets);
+			MakeDoor = new MakeDoorSettings(General.Map.Config.MakeDoorDoor, General.Map.Config.MakeDoorTrack, General.Map.Config.MakeDoorCeiling, MakeDoor.ResetOffsets, MakeDoor.ApplyActionSpecials, MakeDoor.ApplyTag);
 			ResetCopyProperties();
 		}
 
@@ -720,10 +724,10 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(ti != null)
 					{
 						if(  ((ti.Args[0].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[0]))) ||
-						     ((ti.Args[1].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[1]))) ||
-						     ((ti.Args[2].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[2]))) ||
-						     ((ti.Args[3].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[3]))) ||
-						     ((ti.Args[4].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[4]))))
+							 ((ti.Args[1].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[1]))) ||
+							 ((ti.Args[2].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[2]))) ||
+							 ((ti.Args[3].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[3]))) ||
+							 ((ti.Args[4].Type == (int)asso.Type) && (asso.Tags.Contains(t.Args[4]))))
 						{
 							renderer.RenderThing(t, General.Colors.Indication, General.Settings.ActiveThingsAlpha);
 							if(General.Settings.GZShowEventLines) eventlines.Add(new Line3D(t.Position, asso.Center));

--- a/Source/Plugins/BuilderModes/Interface/MakeDoorForm.Designer.cs
+++ b/Source/Plugins/BuilderModes/Interface/MakeDoorForm.Designer.cs
@@ -39,6 +39,8 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 			this.resetoffsets = new System.Windows.Forms.CheckBox();
 			this.tracktexture = new CodeImp.DoomBuilder.Controls.TextureSelectorControl();
 			this.label4 = new System.Windows.Forms.Label();
+			this.applyactionspecials = new System.Windows.Forms.CheckBox();
+			this.applytag = new System.Windows.Forms.CheckBox();
 			this.SuspendLayout();
 			// 
 			// doortexture
@@ -102,7 +104,7 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 			// cancel
 			// 
 			this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancel.Location = new System.Drawing.Point(279, 140);
+			this.cancel.Location = new System.Drawing.Point(279, 163);
 			this.cancel.Name = "cancel";
 			this.cancel.Size = new System.Drawing.Size(83, 25);
 			this.cancel.TabIndex = 4;
@@ -112,7 +114,7 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 			// 
 			// apply
 			// 
-			this.apply.Location = new System.Drawing.Point(190, 140);
+			this.apply.Location = new System.Drawing.Point(190, 163);
 			this.apply.Name = "apply";
 			this.apply.Size = new System.Drawing.Size(83, 25);
 			this.apply.TabIndex = 3;
@@ -152,13 +154,39 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 			this.label4.Text = "Track";
 			this.label4.TextAlign = System.Drawing.ContentAlignment.TopCenter;
 			// 
+			// applyactionspecials
+			// 
+			this.applyactionspecials.AutoSize = true;
+			this.applyactionspecials.Checked = true;
+			this.applyactionspecials.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.applyactionspecials.Location = new System.Drawing.Point(148, 140);
+			this.applyactionspecials.Name = "applyactionspecials";
+			this.applyactionspecials.Size = new System.Drawing.Size(125, 17);
+			this.applyactionspecials.TabIndex = 8;
+			this.applyactionspecials.Text = "Apply action specials";
+			this.applyactionspecials.UseVisualStyleBackColor = true;
+			// 
+			// applytag
+			// 
+			this.applytag.AutoSize = true;
+			this.applytag.Checked = true;
+			this.applytag.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.applytag.Location = new System.Drawing.Point(292, 140);
+			this.applytag.Name = "applytag";
+			this.applytag.Size = new System.Drawing.Size(70, 17);
+			this.applytag.TabIndex = 9;
+			this.applytag.Text = "Apply tag";
+			this.applytag.UseVisualStyleBackColor = true;
+			// 
 			// MakeDoorForm
 			// 
 			this.AcceptButton = this.apply;
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.CancelButton = this.cancel;
-			this.ClientSize = new System.Drawing.Size(372, 170);
+			this.ClientSize = new System.Drawing.Size(372, 197);
+			this.Controls.Add(this.applytag);
+			this.Controls.Add(this.applyactionspecials);
 			this.Controls.Add(this.tracktexture);
 			this.Controls.Add(this.label4);
 			this.Controls.Add(this.resetoffsets);
@@ -198,5 +226,7 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 		private System.Windows.Forms.CheckBox resetoffsets;
 		private CodeImp.DoomBuilder.Controls.TextureSelectorControl tracktexture;
 		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.CheckBox applyactionspecials;
+		private System.Windows.Forms.CheckBox applytag;
 	}
 }

--- a/Source/Plugins/BuilderModes/Interface/MakeDoorForm.cs
+++ b/Source/Plugins/BuilderModes/Interface/MakeDoorForm.cs
@@ -33,6 +33,8 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 		public string CeilingTexture { get { return ceilingtexture.TextureName; } }
 		public string FloorTexture { get { return floortexture.TextureName; } }
 		public bool ResetOffsets { get { return resetoffsets.Checked; } }
+		public bool ApplyActionSpecials {  get { return applyactionspecials.Checked; } }
+		public bool ApplyTag { get { return applytag.Checked; } }
 
 		#endregion
 		
@@ -45,13 +47,15 @@ namespace CodeImp.DoomBuilder.BuilderModes.Interface
 		}
 
 		// This sets the properties and shows the form
-		public DialogResult Show(IWin32Window owner, string doortex, string tracktex, string ceilingtex, string floortex, bool roffsets)
+		public DialogResult Show(IWin32Window owner, string doortex, string tracktex, string ceilingtex, string floortex, bool roffsets, bool applyactionspecials, bool applytag)
 		{
 			this.doortexture.TextureName = doortex;
 			this.tracktexture.TextureName = tracktex;
 			this.ceilingtexture.TextureName = ceilingtex;
 			this.floortexture.TextureName = floortex;
 			this.resetoffsets.Checked = roffsets;
+			this.applyactionspecials.Checked = applyactionspecials;
+			this.applytag.Checked = applytag;
 			return this.ShowDialog(owner);
 		}
 		


### PR DESCRIPTION
Added a couple of options to the MakeDoor form, making adding the 202 line specials optional and adding the option to add a tag to the created sector(s) (helps when creating remote/secret doors).