### PR TITLE
Adds error check for vertices with non-integer positions

### DIFF
--- a/Source/Plugins/BuilderModes/ErrorChecks/CheckOffGridVertices.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/CheckOffGridVertices.cs
@@ -1,0 +1,44 @@
+using CodeImp.DoomBuilder.Map;
+using System.Threading;
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+    [ErrorChecker("Check off-grid vertices", true, 50)]
+    public class CheckOffGridVertices : ErrorChecker
+    {
+        private const int PROGRESS_STEP = 1000;
+
+        // Constructor
+        public CheckOffGridVertices()
+        {
+            // Total progress is done when all vertices are checked
+            SetTotalProgress(General.Map.Map.Vertices.Count / PROGRESS_STEP);
+        }
+
+        // This runs the check
+        public override void Run()
+        {
+            int progress = 0;
+            int stepprogress = 0;
+
+            // Go for all vertices
+            foreach (Vertex v in General.Map.Map.Vertices)
+            {
+                if (v.Position.x != (int)v.Position.x || v.Position.y != (int)v.Position.y)
+                {
+                    SubmitResult(new ResultOffGridVertex(v));
+                }
+
+                // Handle thread interruption
+                try { Thread.Sleep(0); } catch (ThreadInterruptedException) { return; }
+
+                // We are making progress!
+                if ((++progress / PROGRESS_STEP) > stepprogress)
+                {
+                    stepprogress = (progress / PROGRESS_STEP);
+                    AddProgress(1);
+                }
+            }
+        }
+    }
+}

--- a/Source/Plugins/BuilderModes/ErrorChecks/ResultOffGridVertex.cs
+++ b/Source/Plugins/BuilderModes/ErrorChecks/ResultOffGridVertex.cs
@@ -1,0 +1,75 @@
+#region ================== Namespaces
+
+using System;
+using CodeImp.DoomBuilder.Map;
+using CodeImp.DoomBuilder.Rendering;
+using System.Drawing;
+
+#endregion
+
+namespace CodeImp.DoomBuilder.BuilderModes
+{
+    public class ResultOffGridVertex : ErrorResult
+    {
+        #region ================== Variables
+
+        private readonly Vertex vertex;
+
+        #endregion
+
+        #region ================== Properties
+
+        public override int Buttons { get { return 1; } }
+        public override string Button1Text { get { return "Align Vertex"; } }
+
+        #endregion
+
+        #region ================== Constructor / Destructor
+
+        public ResultOffGridVertex(Vertex v)
+        {
+            // Initialize
+            vertex = v;
+            viewobjects.Add(v);
+            hidden = v.IgnoredErrorChecks.Contains(this.GetType());
+            description = "This vertex is not aligned with the grid.";
+        }
+
+        #endregion
+
+        #region ================== Methods
+
+        // This sets if this result is displayed in ErrorCheckForm (mxd)
+        internal override void Hide(bool hide)
+        {
+            hidden = hide;
+            Type t = this.GetType();
+            if (hide) vertex.IgnoredErrorChecks.Add(t);
+            else if (vertex.IgnoredErrorChecks.Contains(t)) vertex.IgnoredErrorChecks.Remove(t);
+        }
+
+        // This must return the string that is displayed in the listbox
+        public override string ToString()
+        {
+            return "Vertex " + vertex.Index + " at " + vertex.Position.x + ", " + vertex.Position.y + " is not aligned with the grid.";
+        }
+
+        // Rendering
+        public override void RenderOverlaySelection(IRenderer2D renderer)
+        {
+            renderer.RenderRectangleFilled(new RectangleF(vertex.Position.x - 3, vertex.Position.y - 3, 6f, 6f), General.Colors.Selection, true);
+        }
+
+        // This removes the vertex
+        public override bool Button1Click(bool batchMode)
+        {
+            if (!batchMode) General.Map.UndoRedo.CreateUndo("Align vertex");
+            vertex.Move(new Geometry.Vector2D((int)Math.Round(vertex.Position.x), (int)Math.Round(vertex.Position.y)));
+            General.Map.IsChanged = true;
+            General.Map.ThingsFilter.Update();
+            return true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Wasn't sure what to call this one - went with "off-grid" instead of "unaligned" because "unaligned" already has a different meaning in GZDB. Assists particularly when making jagged outdoor areas, avoiding BSP holes from the node builder.