### PR TITLE
Replace the wrong portal_ceil_alpha and portal_floor_alpha with alpha…

### DIFF
--- a/Build/Configurations/Includes/Eternity_misc.cfg
+++ b/Build/Configurations/Includes/Eternity_misc.cfg
@@ -109,20 +109,20 @@ floorterain, ceilingterrain, floor/ceiling panning/rotation */
 			type = 2;
 			default = "none";
 		}
-		portal_ceil_alpha
+		alphaceiling
 		{
-			type = 0;
-			default = 255;
+			type = 1;
+			default = 1;
 		}
 		portal_floor_overlaytype
 		{
 			type = 2;
 			default = "none";
 		}
-		portal_floor_alpha
+		alphafloor
 		{
-			type = 0;
-			default = 255;
+			type = 1;
+			default = 1;
 		}
 		portalfloor
 		{


### PR DESCRIPTION
…ceiling and alphafloor.

Now they're the correct ones. Dunno if they were really needed though, if the slopes/portals tab didn't already show them.