### PR TITLE
The indoor lightning descriptions were reversed.

### DIFF
--- a/Build/Configurations/Includes/ZDoom_sectors.cfg
+++ b/Build/Configurations/Includes/ZDoom_sectors.cfg
@@ -60,8 +60,8 @@ zdoom
 	195 = "Hidden Sector (automap)";
 	196 = "Healing Sector";
 	197 = "Lightning Outdoor";
-	198 = "Lightning Indoor 2";
-	199 = "Lightning Indoor 1";
+	198 = "Lightning Indoor 1";
+	199 = "Lightning Indoor 2";
 	200 = "Sky 2 (MAPINFO)";
 	201 = "Scroll North (slow)";
 	202 = "Scroll North (medium)";


### PR DESCRIPTION
Special 198 is `Light_IndoorLightning1` (which is brighter), while special 199 is  `Light_IndoorLightning2` (which is dimmer). 

**References**
- https://zdoom.org/wiki/Lightning
- https://zdoom.org/wiki/Sector_specials
- Tested in GZDoom 3.2.1x64


**Note**
`Build/Configurations/Includes/Eternity_misc.cfg` also contains the same data, however they are commented out and I don't know if Eternity has them reversed so I didn't make the change here.