### PR TITLE
Added paint selecting to visual mode

### DIFF
--- a/Source/Plugins/BuilderModes/Resources/Actions.cfg
+++ b/Source/Plugins/BuilderModes/Resources/Actions.cfg
@@ -1391,3 +1391,17 @@ ceilingalignmode
 	allowmouse = true;
 	allowscroll = true;
 }
+
+// biwa
+visualpaintselect
+{
+	title = "Paint Selection";
+	category = "visual";
+	description = "Selects or deselects items by dragging the mouse. Hold shift while dragging to toggle additive selection. Hold Ctrl while dragging to enable subtractive selection";
+	allowkeys = true;
+	allowmouse = true;
+	allowscroll = false;
+	disregardshift = true;
+	disregardcontrol = true;
+	disregardalt = true;
+}

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySector.cs
@@ -449,6 +449,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public virtual void ApplyLowerUnpegged(bool set) { }
 		protected abstract void MoveTextureOffset(int offsetx, int offsety);
 		protected abstract Point GetTextureOffset();
+		public virtual void OnPaintSelectEnd() { } // biwa
 
 		// Setup this plane
 		public bool Setup() { return this.Setup(this.level, this.extrafloor); }
@@ -501,6 +502,37 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// Moving the mouse
 		public virtual void OnMouseMove(MouseEventArgs e)
 		{
+			// biwa. Paint selection going on?
+			if(mode.PaintSelectPressed)
+			{
+				// toggle selected state
+				if (mode.PaintSelectType == this.GetType().BaseType && mode.Highlighted != this) // using BaseType so that both floor and ceiling can be selected in one go
+				{
+					if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+					{
+						this.selected = true;
+						mode.AddSelectedObject(this);
+					}
+					else if (General.Interface.CtrlState)
+					{
+						this.selected = false;
+						mode.RemoveSelectedObject(this);
+
+					}
+					else
+					{
+						if (this.selected)
+							mode.RemoveSelectedObject(this);
+						else
+							mode.AddSelectedObject(this);
+
+						this.selected = !this.selected;
+					}
+				}
+
+				return;
+			}
+
 			if(!General.Map.UDMF) return; //mxd. Cannot change texture offsets in other map formats...
 			
 			// Dragging UV?
@@ -970,6 +1002,34 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			}
 
 			if(vs != null) vs.UpdateSectorGeometry(false);
+		}
+
+		// biwa
+		public virtual void OnPaintSelectBegin()
+		{
+			mode.PaintSelectType = this.GetType().BaseType; // using BaseType so that both floor and ceiling can be selected in one go
+
+			// toggle selected state
+			if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+			{
+				this.selected = true;
+				mode.AddSelectedObject(this);
+			}
+			else if (General.Interface.CtrlState)
+			{
+				this.selected = false;
+				mode.RemoveSelectedObject(this);
+
+			}
+			else
+			{
+				if (this.selected)
+					mode.RemoveSelectedObject(this);
+				else
+					mode.AddSelectedObject(this);
+
+				this.selected = !this.selected;
+			}
 		}
 		
 		#endregion

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualGeometrySidedef.cs
@@ -833,7 +833,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		protected abstract void MoveTextureOffset(int offsetx, int offsety);
 		protected abstract Point GetTextureOffset();
 		public virtual void OnTextureFit(FitTextureOptions options) { } //mxd
-		
+		public virtual void OnPaintSelectEnd() { } // biwa
+
 		// Insert middle texture
 		public virtual void OnInsert()
 		{
@@ -1414,6 +1415,35 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			{
 				UpdateDragUV();
 			}
+			else if (mode.PaintSelectPressed) // biwa. Paint selection going on?
+			{
+				if (mode.PaintSelectType == this.GetType().BaseType && mode.Highlighted != this) // using BaseType so that middle, upper, lower, etc can be selecting in one go
+				{
+					// toggle selected state
+					if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+					{
+						this.selected = true;
+						mode.AddSelectedObject(this);
+					}
+					else if (General.Interface.CtrlState)
+					{
+						this.selected = false;
+						mode.RemoveSelectedObject(this);
+
+					}
+					else
+					{
+						if (this.selected)
+							mode.RemoveSelectedObject(this);
+						else
+							mode.AddSelectedObject(this);
+
+						this.selected = !this.selected;
+					}
+				}
+
+				return;
+			}
 			else
 			{
 				// Select button pressed?
@@ -1665,6 +1695,33 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			if(sd != null) sd.Reset(true);
 
 			mode.SetActionResult("Wall scale changed to " + scaleX.ToString("F03", CultureInfo.InvariantCulture) + ", " + scaleY.ToString("F03", CultureInfo.InvariantCulture) + " (" + (int)Math.Round(Texture.Width / scaleX) + " x " + (int)Math.Round(Texture.Height / scaleY) + ").");
+		}
+
+		// biwa
+		public virtual void OnPaintSelectBegin()
+		{
+			mode.PaintSelectType = this.GetType().BaseType; // using BaseType so that middle, upper, lower, etc can be selecting in one go
+
+			// toggle selected state
+			if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+			{
+				this.selected = true;
+				mode.AddSelectedObject(this);
+			}
+			else if (General.Interface.CtrlState)
+			{
+				this.selected = false;
+				mode.RemoveSelectedObject(this);
+			}
+			else
+			{
+				if (this.selected)
+					mode.RemoveSelectedObject(this);
+				else
+					mode.AddSelectedObject(this);
+
+				this.selected = !this.selected;
+			}
 		}
 
 		#endregion

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualThing.cs
@@ -646,7 +646,6 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		// Unused
 		public void OnSelectBegin() { }
 		public void OnEditBegin() { }
-		public void OnMouseMove(MouseEventArgs e) { }
 		public void OnChangeTargetBrightness(bool up) { }
 		public void OnChangeTextureOffset(int horizontal, int vertical, bool doSurfaceAngleCorrection) { }
 		public void OnSelectTexture() { }
@@ -665,7 +664,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }
 		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
-		
+		public virtual void OnPaintSelectEnd() { } // biwa
+
 		// Return texture name
 		public string GetTextureName() { return ""; }
 
@@ -857,6 +857,66 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			}
 
 			this.Changed = true;
+		}
+
+		// biwa. Moving the mouse
+		public virtual void OnMouseMove(MouseEventArgs e)
+		{
+			// biwa. Paint selection going on?
+			if (mode.PaintSelectPressed)
+			{
+				// toggle selected state
+				if (mode.PaintSelectType == this.GetType() && mode.Highlighted != this)
+				{
+					if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+					{
+						this.selected = true;
+						mode.AddSelectedObject(this);
+					}
+					else if (General.Interface.CtrlState)
+					{
+						this.selected = false;
+						mode.RemoveSelectedObject(this);
+
+					}
+					else
+					{
+						if (this.selected)
+							mode.RemoveSelectedObject(this);
+						else
+							mode.AddSelectedObject(this);
+
+						this.selected = !this.selected;
+					}
+				}
+			}
+		}
+
+		// biwa
+		public virtual void OnPaintSelectBegin()
+		{
+			mode.PaintSelectType = this.GetType();
+
+			// toggle selected state
+			if (General.Interface.ShiftState ^ BuilderPlug.Me.AdditiveSelect)
+			{
+				this.selected = true;
+				mode.AddSelectedObject(this);
+			}
+			else if (General.Interface.CtrlState)
+			{
+				this.selected = false;
+				mode.RemoveSelectedObject(this);
+			}
+			else
+			{
+				if (this.selected)
+					mode.RemoveSelectedObject(this);
+				else
+					mode.AddSelectedObject(this);
+
+				this.selected = !this.selected;
+			}
 		}
 
 		//mxd

--- a/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/BaseVisualVertex.cs
@@ -262,6 +262,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void ApplyLowerUnpegged(bool set) { }
 		public string GetTextureName() { return ""; }
 		public void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight) { } //mxd
+		public virtual void OnPaintSelectBegin() { } // biwa
+		public virtual void OnPaintSelectEnd() { } // biwa
 
 		#endregion
 

--- a/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/IVisualEventReceiver.cs
@@ -54,6 +54,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		void OnProcess(long deltatime);
 		void OnInsert();
 		void OnDelete();
+		void OnPaintSelectBegin(); // biwa
+		void OnPaintSelectEnd(); // biwa
 
 		// Assist functions
 		void ApplyTexture(string texture);

--- a/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/NullVisualEventReceiver.cs
@@ -53,6 +53,8 @@ namespace CodeImp.DoomBuilder.BuilderModes
 		public void OnProcess(long deltatime) { }
 		public void OnInsert() { }
 		public void OnDelete() { }
+		public void OnPaintSelectBegin() { } // biwa
+		public void OnPaintSelectEnd() { } // biwa
 		public void ApplyTexture(string texture) { }
 		public void ApplyUpperUnpegged(bool set) { }
 		public void ApplyLowerUnpegged(bool set) { }


### PR DESCRIPTION
Works just like paint selection in classic modes. No default key bound. Works on floors/ceilings, any parts of lines, and things. Only the type you started to paint select on will be selected, i.e. if you start paint selecting on a floor you can't accidentally select walls.

With the default picking interval of 80 ms it is too unreliable (no selection will happen if the mouse movement is too fast), so while paint selecting the picking interval gets reduced to 10 ms. I assume it is at 80 ms by default because of performance reasons, but I didn't notice any additional slowdown even in massive maps (like Vela Pax), but I have no means of profiling.

Video of paint selection in action: https://www.youtube.com/watch?v=03RK-U2B7Ic