### PR TITLE
Various fixes for rotated grid functionality

### DIFF
--- a/Source/Core/Geometry/Line2D.cs
+++ b/Source/Core/Geometry/Line2D.cs
@@ -231,11 +231,10 @@ namespace CodeImp.DoomBuilder.Geometry
 		{
 			int flags1 = MapSet.GetCSFieldBits(line.v1, rect);
 			int flags2 = MapSet.GetCSFieldBits(line.v2, rect);
-			Line2D result = line;
 			intersects = false;
 
-			// Each pass will modify one coordinate of one endpoint
-			for (int pass = 0; pass < 4; pass++)
+			Line2D result = line;
+			while (true)
 			{
 				if (flags1 == 0 && flags2 == 0)
 				{
@@ -247,6 +246,7 @@ namespace CodeImp.DoomBuilder.Geometry
 				if ((flags1 & flags2) != 0)
 				{
 					// Both points are in the same outer area
+					intersects = false;
 					return new Line2D();
 				}
 
@@ -254,43 +254,41 @@ namespace CodeImp.DoomBuilder.Geometry
 				int outFlags = flags1 != 0 ? flags1 : flags2;
 				if ((outFlags & 0x1) > 0) // Top
 				{
-					x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Top - line.v1.y) / (line.v2.y - line.v1.y);
+					x = result.v1.x + (result.v2.x - result.v1.x) * (rect.Top - result.v1.y) / (result.v2.y - result.v1.y);
 					y = rect.Top;
 				}
 				else if ((outFlags & 0x2) > 0) // Bottom
 				{
-					x = line.v1.x + (line.v2.x - line.v1.x) * (rect.Bottom - line.v1.y) / (line.v2.y - line.v1.y);
+					x = result.v1.x + (result.v2.x - result.v1.x) * (rect.Bottom - result.v1.y) / (result.v2.y - result.v1.y);
 					y = rect.Bottom;
 				}
 				else if ((outFlags & 0x4) > 0) // Left
 				{
-					y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Left - line.v1.x) / (line.v2.x - line.v1.x);
+					y = result.v1.y + (result.v2.y - result.v1.y) * (rect.Left - result.v1.x) / (result.v2.x - result.v1.x);
 					x = rect.Left;
 				}
 				else if ((outFlags & 0x8) > 0) // Right
 				{
-					y = line.v1.y + (line.v2.y - line.v1.y) * (rect.Right - line.v1.x) / (line.v2.x - line.v1.x);
+					y = result.v1.y + (result.v2.y - result.v1.y) * (rect.Right - result.v1.x) / (result.v2.x - result.v1.x);
 					x = rect.Right;
 				} 
 				else
 				{
-					intersects = false;
-					return new Line2D();
+					intersects = true;
+					return result;
 				}
 
 				if (outFlags == flags1)
 				{
-					line.v1 = new Vector2D(x, y);
-					flags1 = MapSet.GetCSFieldBits(line.v1, rect);
+					result.v1 = new Vector2D(x, y);
+					flags1 = MapSet.GetCSFieldBits(result.v1, rect);
 				}
 				else
 				{
-					line.v2 = new Vector2D(x, y);
-					flags2 = MapSet.GetCSFieldBits(line.v2, rect);
+					result.v2 = new Vector2D(x, y);
+					flags2 = MapSet.GetCSFieldBits(result.v2, rect);
 				}
 			}
-
-			return line;
 		}
 		
 		#endregion

--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -839,7 +839,7 @@ namespace CodeImp.DoomBuilder.Rendering
 
 				if(General.Settings.RenderGrid) //mxd
 				{
-					bool transformed = General.Map.Grid.GridOriginX != 0 || General.Map.Grid.GridOriginY != 0 || Math.Abs(General.Map.Grid.GridRotate) > 1e-4;
+					bool transformed = Math.Abs(General.Map.Grid.GridOriginX) > 1e-4 || Math.Abs(General.Map.Grid.GridOriginY) > 1e-4 || Math.Abs(General.Map.Grid.GridRotate) > 1e-4));
 
 					if (transformed)
 					{
@@ -909,15 +909,10 @@ namespace CodeImp.DoomBuilder.Rendering
 				do { size *= 2; } while(size * scale <= 6f);
 			float sizeinv = 1f / size;
 
-			if (size < 1 || size > 1024)
-			{
-				return;
-			}
-
 			// Determine map coordinates for view window
-			Vector2D ltpos = DisplayToMap(new Vector2D(0, 0));
-			Vector2D rbpos = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
-			Vector2D mapsize = rbpos - ltpos;
+			Vector2D ltview = DisplayToMap(new Vector2D(0, 0));
+			Vector2D rbview = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
+			Vector2D mapsize = rbview - ltview;
 
 			Vector2D ltbound = new Vector2D(General.Map.Config.LeftBoundary, General.Map.Config.TopBoundary);
 			Vector2D rbbound = new Vector2D(General.Map.Config.RightBoundary, General.Map.Config.BottomBoundary);
@@ -926,8 +921,7 @@ namespace CodeImp.DoomBuilder.Rendering
 			Vector2D tlb = ltbound.GetTransformed(translatex, translatey, scale, -scale);
 			Vector2D rbb = rbbound.GetTransformed(translatex, translatey, scale, -scale);
 
-			Vector2D xcenter = GridSetup.SnappedToGrid(0.5f * (ltpos + rbpos), size, sizeinv, angle, originx, originy);
-			Vector2D ycenter = xcenter;
+			Vector2D center = GridSetup.SnappedToGrid(0.5f * (ltview + rbview), size, sizeinv, angle, originx, originy);
 
 			// Get the angle vectors for the gridlines
 			Vector2D dx = new Vector2D((float)Math.Cos(angle), (float)Math.Sin(angle));
@@ -935,15 +929,16 @@ namespace CodeImp.DoomBuilder.Rendering
 
 			float maxextent = Math.Max(mapsize.x, mapsize.y);
 			RectangleF bounds = new RectangleF(tlb.x, tlb.y, rbb.x - tlb.x, rbb.y - tlb.y);
+			bounds.Intersect(new RectangleF(0, 0, windowsize.Width, windowsize.Height));
 
 			bool xminintersect = true, xmaxintersect = true, yminintersect = true, ymaxintersect = true;
 
 			int num = 0;            
 			while (xminintersect || xmaxintersect || yminintersect || ymaxintersect) {
-				Vector2D xminstart = xcenter - num * size * dy;
-				Vector2D xmaxstart = xcenter + num * size * dy;
-				Vector2D yminstart = ycenter - num * size * dx;
-				Vector2D ymaxstart = ycenter + num * size * dx;
+				Vector2D xminstart = center - num * size * dy;
+				Vector2D xmaxstart = center + num * size * dy;
+				Vector2D yminstart = center - num * size * dx;
+				Vector2D ymaxstart = center + num * size * dx;
 
 				Line2D xminscanline = new Line2D(xminstart - dx * maxextent, xminstart + dx * maxextent);
 				Line2D xmaxscanline = new Line2D(xmaxstart - dx * maxextent, xmaxstart + dx * maxextent);

--- a/Source/Core/Windows/MainForm.cs
+++ b/Source/Core/Windows/MainForm.cs
@@ -2917,7 +2917,8 @@ namespace CodeImp.DoomBuilder.Windows
 		{
 			if (General.Map.Map.SelectedLinedefsCount != 1)
 			{
-				General.ShowErrorMessage("Exactly one linedef must be selected.", MessageBoxButtons.OK);
+				General.Interface.DisplayStatus(StatusType.Warning, "Exactly one linedef must be selected");
+				General.Interface.MessageBeep(MessageBeepType.Warning);
 				return;
 			}
 			Linedef line = General.Map.Map.SelectedLinedefs.First.Value;
@@ -2933,7 +2934,8 @@ namespace CodeImp.DoomBuilder.Windows
 		{
 			if (General.Map.Map.SelectedVerticessCount != 1)
 			{
-				General.ShowErrorMessage("Exactly one vertex must be selected.", MessageBoxButtons.OK);
+				General.Interface.DisplayStatus(StatusType.Warning, "Exactly one vertex must be selected");
+				General.Interface.MessageBeep(MessageBeepType.Warning);
 				return;
 			}
 			Vertex vertex = General.Map.Map.SelectedVertices.First.Value;


### PR DESCRIPTION
This pull request addresses the following issues with PR #252:

- [x] Fix rotated grid disappearing when grid size is finer than 1 unit
- [x] Report usage errors using conventional status bar warning and beep instead of popup dialog box
- [x] Fix an issue with Line2D.ClipToRectangle sometimes incorrectly culling gridlines when zoomed all the way out
- [x] Correctly clip gridlines to map unit boundaries when zoomed all the way out