### PR TITLE
Fix for rotated grid algorithm causing a freeze in some circumstances

### DIFF
--- a/Source/Core/Rendering/Renderer2D.cs
+++ b/Source/Core/Rendering/Renderer2D.cs
@@ -908,6 +908,11 @@ namespace CodeImp.DoomBuilder.Rendering
 				do { size *= 2; } while(size * scale <= 6f);
 			float sizeinv = 1f / size;
 
+			if (float.IsInfinity(size) || size < 1e-10)
+			{
+				return;
+			}
+
 			// Determine map coordinates for view window
 			Vector2D ltview = DisplayToMap(new Vector2D(0, 0));
 			Vector2D rbview = DisplayToMap(new Vector2D(windowsize.Width, windowsize.Height));
@@ -934,6 +939,12 @@ namespace CodeImp.DoomBuilder.Rendering
 
 			int num = 0;            
 			while (xminintersect || xmaxintersect || yminintersect || ymaxintersect) {
+				if (num > 1e6)
+				{
+					// just in case garbage inputs breaks the algorithm and causes an infinite loop
+					break;
+				}
+
 				Vector2D xminstart = center - num * size * dy;
 				Vector2D xmaxstart = center + num * size * dy;
 				Vector2D yminstart = center - num * size * dx;


### PR DESCRIPTION
This should fix an issue where loading a map with rotated grid settings would cause a freeze or crash. The issue was caused by the 'size' parameter being scaled up to infinity during a map load, which caused the rotated grid algorithm to go into an infinite loop. I mitigated it by both checking for an infinite (or very tiny) size and bailing before the algorithm starts, as well as ensuring that the algorithm can only run for at most 1 million steps.