### PR TITLE
Fix sector offset transformation in Edit Selection mode

### DIFF
--- a/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
@@ -893,13 +893,14 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			float texrotation = Angle2D.PI2 - rotation;
 
 			// Update texture offsets
-			if(transformoffsets)
+			if (transformoffsets)
 			{
-				Vector2D toffset = (selectionbasecenter - selectioncenter).GetRotated((texrotation + si.Rotation));
-				Vector2D soffset = si.Offset.GetRotated(texrotation + si.Rotation);
+				float trotation = rotateoffsets ? (si.Rotation + texrotation) : (si.Rotation);
+				Vector2D offset = selectioncenter.GetRotated(trotation);
 
-				fields["xpanning" + si.Part] = new UniValue(UniversalType.Float, (float)Math.Round(soffset.x + toffset.x, General.Map.FormatInterface.VertexDecimals) % si.TextureSize.Width);
-				fields["ypanning" + si.Part] = new UniValue(UniversalType.Float, (float)Math.Round(-(soffset.y + toffset.y), General.Map.FormatInterface.VertexDecimals) % si.TextureSize.Height);
+				fields["xpanning" + si.Part] = new UniValue(UniversalType.Float, (float)Math.Round(-offset.x, General.Map.FormatInterface.VertexDecimals));
+				fields["ypanning" + si.Part] = new UniValue(UniversalType.Float, (float)Math.Round(offset.y, General.Map.FormatInterface.VertexDecimals));
+
 			}
 			// Restore texture offsets
 			else 
@@ -1825,7 +1826,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					renderer.RenderRectangleFilled(rotategrips[i], General.Colors.Background, true);
 					renderer.RenderRectangle(rotategrips[i], 2, General.Colors.Indication, true);
 				}
-				
+
 				renderer.Finish();
 			}
 


### PR DESCRIPTION
When editing sectors in Edit mode with "Floor/Ceiling textures transform" checkboxes checked, offsets are not transformed properly (most noticeable when moving and rotating the sectors). This PR fixes this issue.