### PR TITLE
Support for RenderRadius

### DIFF
--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -71,6 +71,7 @@ namespace CodeImp.DoomBuilder.Config
 		private bool bright; //mxd
 		private bool arrow;
 		private float radius;
+		private float renderradius;
 		private float height;
 		private int distancechecksq; //mxd. Contains squared value or int.MaxValue when not set
 		private bool hangs;
@@ -120,6 +121,7 @@ namespace CodeImp.DoomBuilder.Config
 		public bool Bright { get { return bright; } } //mxd
 		public bool Arrow { get { return arrow; } }
 		public float Radius { get { return radius; } }
+		public float RenderRadius { get { return renderradius; } }
 		public float Height { get { return height; } }
 		public int DistanceCheckSq { get { return distancechecksq; } } //mxd
 		public bool Hangs { get { return hangs; } }
@@ -177,6 +179,7 @@ namespace CodeImp.DoomBuilder.Config
 			this.bright = false; //mxd
 			this.arrow = true;
 			this.radius = 10f;
+			this.renderradius = 10f;
 			this.height = 20f;
 			this.distancechecksq = int.MaxValue; //mxd
 			this.hangs = false;
@@ -552,6 +555,9 @@ namespace CodeImp.DoomBuilder.Config
 			// Size
 			if(actor.HasPropertyWithValue("radius")) radius = actor.GetPropertyValueInt("radius", 0);
 			if(actor.HasPropertyWithValue("height")) height = actor.GetPropertyValueInt("height", 0);
+			if (actor.HasPropertyWithValue("renderradius")) renderradius = actor.GetPropertyValueInt("renderradius", 0);
+			if (renderradius == 0)
+				renderradius = radius;
 
 			//mxd. DistanceCheck. The value is CVAR. Also we'll need squared value
 			if(actor.HasPropertyWithValue("distancecheck"))

--- a/Source/Core/Map/Thing.cs
+++ b/Source/Core/Map/Thing.cs
@@ -80,6 +80,7 @@ namespace CodeImp.DoomBuilder.Map
 
 		// Configuration
 		private float size;
+		private float rendersize;
 		private float height; //mxd
 		private PixelColor color;
 		private bool fixedsize;
@@ -106,6 +107,7 @@ namespace CodeImp.DoomBuilder.Map
 		public int Action { get { return action; } set { BeforePropsChange(); action = value; } }
 		public int[] Args { get { return args; } }
 		public float Size { get { return size; } }
+		public float RenderSize { get { return rendersize; } }
 		public float Height { get { return height; } } //mxd
 		public PixelColor Color { get { return color; } }
 		public bool FixedSize { get { return fixedsize; } }
@@ -242,6 +244,7 @@ namespace CodeImp.DoomBuilder.Map
 			t.action = action;
 			t.args = (int[])args.Clone();
 			t.size = size;
+			t.rendersize = rendersize;
 			t.height = height; //mxd
 			t.color = color;
 			t.directional = directional;
@@ -532,6 +535,7 @@ namespace CodeImp.DoomBuilder.Map
                 dynamiclighttype = ti.DynamicLightType;
             //General.ErrorLogger.Add(ErrorType.Warning, string.Format("thing dynamiclighttype is {0}; class is {1}", dynamiclighttype, ti.Actor.ClassName));
 			size = ti.Radius;
+			rendersize = ti.RenderRadius;
 			height = ti.Height; //mxd
 			fixedsize = ti.FixedSize;
 			spritescale = ti.SpriteScale; //mxd

--- a/Source/Core/VisualModes/VisualBlockMap.cs
+++ b/Source/Core/VisualModes/VisualBlockMap.cs
@@ -266,8 +266,8 @@ namespace CodeImp.DoomBuilder.VisualModes
 		public void AddThing(Thing t)
 		{
 			//mxd
-			Point p1 = GetBlockCoordinates(new Vector2D(t.Position.x - t.Size, t.Position.y - t.Size));
-			Point p2 = GetBlockCoordinates(new Vector2D(t.Position.x + t.Size, t.Position.y + t.Size));
+			Point p1 = GetBlockCoordinates(new Vector2D(t.Position.x - t.RenderSize, t.Position.y - t.RenderSize));
+			Point p2 = GetBlockCoordinates(new Vector2D(t.Position.x + t.RenderSize, t.Position.y + t.RenderSize));
 			for(int x = p1.X; x <= p2.X; x++)
 			{
 				for(int y = p1.Y; y <= p2.Y; y++)


### PR DESCRIPTION
I am working with _very_ large models, but like to use small radii so that it's thing rectangle doesn't cover half the map in the editor.

The simple solution is to just use the RenderRadius property, which works fine in gzdoom, but is missing support in the editor itself.