### PR TITLE
Cursor position playtesting: stop always marking map changed

### DIFF
--- a/Source/Core/Editing/ClassicMode.cs
+++ b/Source/Core/Editing/ClassicMode.cs
@@ -83,6 +83,7 @@ namespace CodeImp.DoomBuilder.Editing
 		private Thing playerStart;
 		private Vector3D playerStartPosition;
 		private bool playerStartIsTempThing;
+		private bool mapWasChangedBeforeTest;
 		
 		#endregion
 
@@ -728,6 +729,9 @@ namespace CodeImp.DoomBuilder.Editing
 					return false;
 				}
 
+				// Capture whether the map was changed before modifying player things.
+				mapWasChangedBeforeTest = General.Map.IsChanged;
+
 				//find Single Player Start. Should be type 1 in all games
 				Thing start = null;
 				
@@ -806,6 +810,13 @@ namespace CodeImp.DoomBuilder.Editing
 				}
 
 				playerStart = null;
+
+				// Restore the value of General.Map.IsChanged before player
+				// things were modified in OnMapTestBegin().
+				if (!mapWasChangedBeforeTest)
+				{
+					General.Map.ForceMapIsChangedFalse();
+				}
 			}
 		}
 


### PR DESCRIPTION
Following https://github.com/jewalky/UltimateDoomBuilder/pull/543 & https://github.com/jewalky/UltimateDoomBuilder/commit/95f5c719b7c104de72455bde4e5e2a92e6f53b18

When the current map isn't marked as changed because it was just opened or saved, `CTRL+F9` on a mouse cursor position shouldn't mark the map as changed. Player thing modifications are reverted when returning from the playtesting session and the undo/redo manager doesn't have a new checkpoint so the map state should remain `General.Map.IsChanged == false`.