### PR TITLE
Added green and gold player start things to the Zandronum configurations

### DIFF
--- a/Build/Configurations/Includes/Zandronum_common.cfg
+++ b/Build/Configurations/Includes/Zandronum_common.cfg
@@ -46,6 +46,16 @@ things
 				title = "Player Temporary start (team start)";
 				sprite = "PLAYF1";
 			}
+			5083
+			{
+				title = "Player Green start (team start)";
+				sprite = "PLAYD2D8";
+			}
+			5084
+			{
+				title = "Player Gold start (team start)";
+				sprite = "PLAYB2B8";
+			}
 		}
 
 		flags


### PR DESCRIPTION
These have been part of Zandronum for [a long while](https://foss.heptapod.net/zandronum/zandronum-stable/-/commit/86844fa90c0a8151bf1b151dca4b2244020a261e), but they were seemingly never added to the DB configs.