### PR TITLE
Minor plane-related fixes and improvements

### DIFF
--- a/Source/Core/Map/Sector.cs
+++ b/Source/Core/Map/Sector.cs
@@ -699,7 +699,8 @@ namespace CodeImp.DoomBuilder.Map
 					}
 
 					// Have slope?
-					return (sloped ? new Geometry.Plane(verts[0], verts[1], verts[2], true) : floor);
+					if(sloped)
+						return new Geometry.Plane(verts[0], verts[1], verts[2], true);
 				}
 			}
 
@@ -779,7 +780,8 @@ namespace CodeImp.DoomBuilder.Map
 					}
 
 					// Have slope?
-					return (sloped ? new Geometry.Plane(verts[0], verts[2], verts[1], false) : ceiling);
+					if(sloped)
+						return new Geometry.Plane(verts[0], verts[2], verts[1], false);
 				}
 			}
 

--- a/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/EditSelectionMode.cs
@@ -1686,6 +1686,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							if (size.x < 0.0f) normal.x *= -1;
 							if (size.y < 0.0f) normal.y *= -1;
 
+							normal.x /= size.x / basesize.x;
+							normal.y /= size.y / basesize.y;
+
 							double angle = normal.GetAngleXY() + rotation + Angle2D.PIHALF;
 
 							// Get the center of the *new* sector position. Use the z value of the center *old* sector position
@@ -1693,7 +1696,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							Vector3D newcenter = GetTransformedVector(originalcenter);
 							newcenter.z = new Plane(s.FloorSlope, s.FloorSlopeOffset).GetZ(originalcenter);
 
-							Plane p = new Plane(newcenter, angle, -s.FloorSlope.GetAngleZ(), true);
+							Plane p = new Plane(newcenter, angle, -normal.GetAngleZ(), true);
 							s.FloorSlope = p.Normal;
 							s.FloorSlopeOffset = p.Offset;
 						}
@@ -1716,6 +1719,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 								if (size.x < 0.0f) normal.x *= -1;
 								if (size.y < 0.0f) normal.y *= -1;
 
+								normal.x /= size.x / basesize.x;
+								normal.y /= size.y / basesize.y;
+
 								double angle = normal.GetAngleXY() + rotation + Angle2D.PIHALF;
 
 								// Get the center of the *new* tagged sector position. Use the z value of the center *old* tagged sector position
@@ -1723,7 +1729,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 								Vector3D newcenter = GetTransformedVector(originalcenter);
 								newcenter.z = new Plane(cs.FloorSlope, cs.FloorSlopeOffset).GetZ(originalcenter);
 
-								Plane p = new Plane(newcenter, angle, -cs.FloorSlope.GetAngleZ(), true);
+								Plane p = new Plane(newcenter, angle, -normal.GetAngleZ(), true);
 								cs.FloorSlope = p.Normal;
 								cs.FloorSlopeOffset = p.Offset;
 
@@ -1739,6 +1745,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							if (size.x < 0.0f) normal.x *= -1;
 							if (size.y < 0.0f) normal.y *= -1;
 
+							normal.x /= size.x / basesize.x;
+							normal.y /= size.y / basesize.y;
+
 							double angle = normal.GetAngleXY() + rotation + Angle2D.PIHALF;
 
 							// Get the center of the *new* sector position. Use the z value of the center *old* sector position
@@ -1746,7 +1755,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 							Vector3D newcenter = GetTransformedVector(originalcenter);
 							newcenter.z = new Plane(s.CeilSlope, s.CeilSlopeOffset).GetZ(originalcenter);
 
-							Plane p = new Plane(newcenter, angle, -s.CeilSlope.GetAngleZ(), false);
+							Plane p = new Plane(newcenter, angle, -normal.GetAngleZ(), false);
 							s.CeilSlope = p.Normal;
 							s.CeilSlopeOffset = p.Offset;
 						}
@@ -1769,6 +1778,9 @@ namespace CodeImp.DoomBuilder.BuilderModes
 								if (size.x < 0.0f) normal.x *= -1;
 								if (size.y < 0.0f) normal.y *= -1;
 
+								normal.x /= size.x / basesize.x;
+								normal.y /= size.y / basesize.y;
+
 								double angle = normal.GetAngleXY() + rotation + Angle2D.PIHALF;
 
 								// Get the center of the *new* tagged sector position. Use the z value of the center *old* tagged sector position
@@ -1776,7 +1788,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 								Vector3D newcenter = GetTransformedVector(originalcenter);
 								newcenter.z = new Plane(cs.CeilSlope, cs.CeilSlopeOffset).GetZ(originalcenter);
 
-								Plane p = new Plane(newcenter, angle, -cs.CeilSlope.GetAngleZ(), false);
+								Plane p = new Plane(newcenter, angle, -normal.GetAngleZ(), false);
 								cs.CeilSlope = p.Normal;
 								cs.CeilSlopeOffset = p.Offset;
 

--- a/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualCeiling.cs
@@ -581,6 +581,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Map.Data.UpdateUsedTextures();
 		}
 
+		private bool ArePlanesSame(Plane p1, Plane p2)
+		{
+			return (
+				Math.Abs(p1.Normal.x - p2.Normal.x) < 0.001 &&
+				Math.Abs(p1.Normal.y - p2.Normal.y) < 0.001 &&
+				Math.Abs(p1.Normal.z - p2.Normal.z) < 0.001 &&
+				Math.Abs(p1.Offset - p2.Offset) < 0.001
+			);
+		}
+
 		//mxd
 		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) 
 		{
@@ -612,7 +622,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(level.sector != Sector.Sector && !regularorvavoom)
 					{
 						if((!withSameTexture || side.Other.Sector.LongFloorTexture == level.sector.LongCeilTexture) &&
-							(!withSameHeight || side.Other.Sector.FloorHeight == level.sector.CeilHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetFloorPlane(side.Other.Sector), Map.Sector.GetCeilingPlane(level.sector)))) 
 						{
 							neighbours.Add(side.Other.Sector);
 
@@ -625,7 +635,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						// (De)select adjacent ceilings
 						if((!withSameTexture || side.Other.Sector.LongCeilTexture == level.sector.LongCeilTexture) &&
-							(!withSameHeight || side.Other.Sector.CeilHeight == level.sector.CeilHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetCeilingPlane(side.Other.Sector), Map.Sector.GetCeilingPlane(level.sector)))) 
 						{
 							neighbours.Add(side.Other.Sector);
 
@@ -640,7 +650,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						if(select == ec.Selected || ec.extrafloor.VavoomType != regularorvavoom) continue;
 						if((!withSameTexture || level.sector.LongCeilTexture == ec.level.sector.LongCeilTexture) &&
-							(!withSameHeight || level.sector.CeilHeight == ec.level.sector.CeilHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetCeilingPlane(level.sector), Map.Sector.GetCeilingPlane(ec.level.sector)))) 
 						{
 							ec.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
@@ -651,7 +661,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						if(select == ef.Selected || ef.ExtraFloor.VavoomType == regularorvavoom) continue;
 						if((!withSameTexture || level.sector.LongCeilTexture == ef.Level.sector.LongFloorTexture) &&
-							(!withSameHeight || level.sector.CeilHeight == ef.Level.sector.FloorHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetCeilingPlane(level.sector), Map.Sector.GetFloorPlane(ef.Level.sector)))) 
 						{
 							ef.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}

--- a/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
+++ b/Source/Plugins/BuilderModes/VisualModes/VisualFloor.cs
@@ -506,6 +506,16 @@ namespace CodeImp.DoomBuilder.BuilderModes
 			General.Map.Data.UpdateUsedTextures();
 		}
 
+		private bool ArePlanesSame(Plane p1, Plane p2)
+		{
+			return (
+				Math.Abs(p1.Normal.x - p2.Normal.x) < 0.001 &&
+				Math.Abs(p1.Normal.y - p2.Normal.y) < 0.001 &&
+				Math.Abs(p1.Normal.z - p2.Normal.z) < 0.001 &&
+				Math.Abs(p1.Offset - p2.Offset) < 0.001
+			);
+		}
+
 		//mxd
 		public override void SelectNeighbours(bool select, bool withSameTexture, bool withSameHeight, bool stopatselected) 
 		{
@@ -537,7 +547,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					if(level.sector != Sector.Sector && !regularorvavoom)
 					{
 						if((!withSameTexture || side.Other.Sector.LongCeilTexture == level.sector.LongFloorTexture) &&
-							(!withSameHeight || side.Other.Sector.CeilHeight == level.sector.FloorHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetCeilingPlane(side.Other.Sector), Map.Sector.GetFloorPlane(level.sector))))
 						{
 							neighbours.Add(side.Other.Sector);
 
@@ -550,7 +560,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						// (De)select adjacent floor
 						if((!withSameTexture || side.Other.Sector.LongFloorTexture == level.sector.LongFloorTexture) &&
-							(!withSameHeight || side.Other.Sector.FloorHeight == level.sector.FloorHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetFloorPlane(side.Other.Sector), Map.Sector.GetFloorPlane(level.sector))))
 						{
 							neighbours.Add(side.Other.Sector);
 
@@ -565,7 +575,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						if(select == ef.Selected || ef.extrafloor.VavoomType != regularorvavoom) continue;
 						if((!withSameTexture || level.sector.LongFloorTexture == ef.level.sector.LongFloorTexture) &&
-							(!withSameHeight || level.sector.FloorHeight == ef.level.sector.FloorHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetFloorPlane(level.sector), Map.Sector.GetFloorPlane(ef.level.sector))))
 						{
 							ef.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}
@@ -576,7 +586,7 @@ namespace CodeImp.DoomBuilder.BuilderModes
 					{
 						if(select == ec.Selected || ec.ExtraFloor.VavoomType == regularorvavoom) continue;
 						if((!withSameTexture || level.sector.LongFloorTexture == ec.Level.sector.LongCeilTexture) &&
-							(!withSameHeight || level.sector.FloorHeight == ec.Level.sector.CeilHeight)) 
+							(!withSameHeight || ArePlanesSame(Map.Sector.GetFloorPlane(level.sector), Map.Sector.GetCeilingPlane(ec.Level.sector))))
 						{
 							ec.SelectNeighbours(select, withSameTexture, withSameHeight, stopatselected);
 						}


### PR DESCRIPTION
- Fix Sector.GetFloor/CeilingPlane() not working at all in non-sloped triangular sectors
- Make it so that ctrl+left-clicking a surface in Visual Mode only selects planes that have the same slope, instead of only considering floor/ceiling height
- Make Edit Selection Mode support basic horizontally rescaling for sloped sectors