### PR TITLE
Floor drifting at large values

### DIFF
--- a/Source/Core/Data/ImageData.cs
+++ b/Source/Core/Data/ImageData.cs
@@ -143,8 +143,11 @@ namespace CodeImp.DoomBuilder.Data
 		public int OffsetX { get { return offsetx; } }
 		public int OffsetY { get { return offsety; } }
 		//mxd. Scaled texture size is integer in ZDoom.
-		public virtual float ScaledWidth { get { return (float)Math.Round(width * scale.x); } }
-		public virtual float ScaledHeight { get { return (float)Math.Round(height * scale.y); } }
+		//smoke. Yeah but this has probably been changed between 10 years ago and now, and aligment is screwed at large values, changing back
+		//public virtual float ScaledWidth { get { return (float)Math.Round(width * scale.x); } }
+		//public virtual float ScaledHeight { get { return (float)Math.Round(height * scale.y); } }
+		public virtual float ScaledWidth { get { return (float)(width * scale.x); } }
+		public virtual float ScaledHeight { get { return (float)(height * scale.y); } }
 		public virtual Vector2D Scale { get { return scale; } }
 		public bool WorldPanning { get { return worldpanning; } }
 		public int NameWidth {  get { return namewidth; } } // biwa


### PR DESCRIPTION
As part of the fixes - fixed ImageData Rounding error which made floors coordinates drift at large values (thanks to boris for pointing where the error was). 
Apparently rounding texture scale in zdoom and derivatives between 10 years ago and now has changed. 
To test new against old one - Map coordinates, at 4000-6000, texture scale at an odd value which should produce fractions - to example mine were 256x256 XScale 3.0, YScale 3.0 - which produces 85 when rounded, but 85.333(3) when not, and that adds up to large map coordinates. Which resulted in drifting of floor textures at such coordinates. 