### PR TITLE
Fixed comments docker getting bogged down by continious redraw calls

### DIFF
--- a/Source/Plugins/CommentsPanel/CommentsDocker.cs
+++ b/Source/Plugins/CommentsPanel/CommentsDocker.cs
@@ -105,7 +105,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 		}
 		
 		// This updates the list for a specific kind of group
-		private void UpdateGroupList(Dictionary<string, CommentInfo> newcomments, Dictionary<string, CommentInfo> comments, Image icon)
+		private void UpdateGroupList(Dictionary<string, CommentInfo> newcomments, Dictionary<string, CommentInfo> comments, Image icon, ref List<DataGridViewRow> rowBatch)
 		{
 			// Remove old comments
 			List<CommentInfo> commentslist = new List<CommentInfo>(comments.Values);
@@ -113,28 +113,29 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 			{
 				if(!newcomments.ContainsKey(c.Comment))
 				{
-					grid.Rows.Remove(c.Row);
+					rowBatch.Remove(c.Row);
 					comments.Remove(c.Comment);
 				}
 			}
 			
 			// Update the list with comments
-			foreach(KeyValuePair<string, CommentInfo> c in newcomments)
+			foreach (KeyValuePair<string, CommentInfo> c in newcomments)
 			{
 				CommentInfo cc = c.Value;
 				
 				if(!comments.ContainsKey(c.Key))
 				{
 					// Create grid row
-					int index = grid.Rows.Add();
-					DataGridViewRow row = grid.Rows[index];
+					//int index = grid.Rows.Add();
+					DataGridViewRow row = new DataGridViewRow(); //grid.Rows[index];
+					row.CreateCells(grid);
 					row.Cells[0].Value = icon;
 					row.Cells[0].Style.Alignment = DataGridViewContentAlignment.TopCenter;
 					row.Cells[0].Style.Padding = new Padding(0, 5, 0, 0);
 					row.Cells[1].Value = cc.Comment;
 					row.Cells[1].Style.WrapMode = DataGridViewTriState.True;
 					row.Cells[1].Tag = cc;
-					
+					rowBatch.Add(row);
 					// Add to list of comments
 					cc.Row = row;
 					comments.Add(c.Key, cc);
@@ -146,6 +147,8 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 					cc.ReplaceElements(c.Value);
 				}
 			}
+			
+
 		}
 		
 		// This sets the timer to update the list very soon
@@ -158,15 +161,27 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 		// This finds all comments and updates the list
 		public void UpdateList()
 		{
-			if(!preventupdate && General.Map.Map.IsSafeToAccess)
+			
+			if (!preventupdate && General.Map.Map.IsSafeToAccess)
 			{
+				//grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
+				//grid.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None;
+				//grid.RowHeadersVisible = false; // Slight speed boost
+				
+				grid.SuspendLayout();
+				var rowBatch = new List<DataGridViewRow>();
+				foreach (DataGridViewRow r in grid.Rows)
+				{
+					rowBatch.Add(r);
+				}
+				//grid.Rows
 				// Update vertices
 				Dictionary<string, CommentInfo> newcomments = new Dictionary<string, CommentInfo>(StringComparer.Ordinal);
 				if(!filtermode.Checked || (General.Editing.Mode.GetType().Name == "VerticesMode"))
 				{
 					foreach(Vertex v in General.Map.Map.Vertices) AddComments(v, newcomments);
 				}
-				UpdateGroupList(newcomments, v_comments, Properties.Resources.VerticesMode);
+				UpdateGroupList(newcomments, v_comments, Properties.Resources.VerticesMode, ref rowBatch);
 
 				// Update linedefs/sidedefs
 				newcomments.Clear();
@@ -175,7 +190,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 					foreach(Linedef l in General.Map.Map.Linedefs) AddComments(l, newcomments);
 					foreach(Sidedef sd in General.Map.Map.Sidedefs) AddComments(sd, newcomments);
 				}
-				UpdateGroupList(newcomments, l_comments, Properties.Resources.LinesMode);
+				UpdateGroupList(newcomments, l_comments, Properties.Resources.LinesMode, ref rowBatch);
 
 				// Update sectors
 				newcomments.Clear();
@@ -183,7 +198,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				{
 					foreach(Sector s in General.Map.Map.Sectors) AddComments(s, newcomments);
 				}
-				UpdateGroupList(newcomments, s_comments, Properties.Resources.SectorsMode);
+				UpdateGroupList(newcomments, s_comments, Properties.Resources.SectorsMode, ref rowBatch);
 
 				// Update things
 				newcomments.Clear();
@@ -191,11 +206,13 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				{
 					foreach(Thing t in General.Map.Map.Things) AddComments(t, newcomments);
 				}
-				UpdateGroupList(newcomments, t_comments, Properties.Resources.ThingsMode);
-
+				UpdateGroupList(newcomments, t_comments, Properties.Resources.ThingsMode, ref rowBatch);
+				grid.Rows.Clear();
+				grid.Rows.AddRange(rowBatch.ToArray());
+				
 				// Sort grid
 				grid.Sort(grid.Columns[1], ListSortDirection.Ascending);
-
+				grid.ResumeLayout();
 				// Update
 				grid.Update();
 

--- a/Source/Plugins/CommentsPanel/CommentsDocker.cs
+++ b/Source/Plugins/CommentsPanel/CommentsDocker.cs
@@ -126,7 +126,6 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				if(!comments.ContainsKey(c.Key))
 				{
 					// Create grid row
-					//int index = grid.Rows.Add();
 					DataGridViewRow row = new DataGridViewRow(); //grid.Rows[index];
 					row.CreateCells(grid);
 					row.Cells[0].Value = icon;
@@ -164,17 +163,12 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 			
 			if (!preventupdate && General.Map.Map.IsSafeToAccess)
 			{
-				//grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
-				//grid.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None;
-				//grid.RowHeadersVisible = false; // Slight speed boost
-				
 				grid.SuspendLayout();
 				var rowBatch = new List<DataGridViewRow>();
 				foreach (DataGridViewRow r in grid.Rows)
 				{
 					rowBatch.Add(r);
 				}
-				//grid.Rows
 				// Update vertices
 				Dictionary<string, CommentInfo> newcomments = new Dictionary<string, CommentInfo>(StringComparer.Ordinal);
 				if(!filtermode.Checked || (General.Editing.Mode.GetType().Name == "VerticesMode"))

--- a/Source/Plugins/CommentsPanel/CommentsDocker.cs
+++ b/Source/Plugins/CommentsPanel/CommentsDocker.cs
@@ -105,7 +105,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 		}
 		
 		// This updates the list for a specific kind of group
-		private void UpdateGroupList(Dictionary<string, CommentInfo> newcomments, Dictionary<string, CommentInfo> comments, Image icon, ref List<DataGridViewRow> rowBatch)
+		private void UpdateGroupList(Dictionary<string, CommentInfo> newcomments, Dictionary<string, CommentInfo> comments, Image icon, List<DataGridViewRow> rowBatch)
 		{
 			// Remove old comments
 			List<CommentInfo> commentslist = new List<CommentInfo>(comments.Values);
@@ -181,7 +181,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				{
 					foreach(Vertex v in General.Map.Map.Vertices) AddComments(v, newcomments);
 				}
-				UpdateGroupList(newcomments, v_comments, Properties.Resources.VerticesMode, ref rowBatch);
+				UpdateGroupList(newcomments, v_comments, Properties.Resources.VerticesMode, rowBatch);
 
 				// Update linedefs/sidedefs
 				newcomments.Clear();
@@ -190,7 +190,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 					foreach(Linedef l in General.Map.Map.Linedefs) AddComments(l, newcomments);
 					foreach(Sidedef sd in General.Map.Map.Sidedefs) AddComments(sd, newcomments);
 				}
-				UpdateGroupList(newcomments, l_comments, Properties.Resources.LinesMode, ref rowBatch);
+				UpdateGroupList(newcomments, l_comments, Properties.Resources.LinesMode, rowBatch);
 
 				// Update sectors
 				newcomments.Clear();
@@ -198,7 +198,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				{
 					foreach(Sector s in General.Map.Map.Sectors) AddComments(s, newcomments);
 				}
-				UpdateGroupList(newcomments, s_comments, Properties.Resources.SectorsMode, ref rowBatch);
+				UpdateGroupList(newcomments, s_comments, Properties.Resources.SectorsMode, rowBatch);
 
 				// Update things
 				newcomments.Clear();
@@ -206,7 +206,7 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 				{
 					foreach(Thing t in General.Map.Map.Things) AddComments(t, newcomments);
 				}
-				UpdateGroupList(newcomments, t_comments, Properties.Resources.ThingsMode, ref rowBatch);
+				UpdateGroupList(newcomments, t_comments, Properties.Resources.ThingsMode, rowBatch);
 				grid.Rows.Clear();
 				grid.Rows.AddRange(rowBatch.ToArray());
 				

--- a/Source/Plugins/CommentsPanel/CommentsDocker.cs
+++ b/Source/Plugins/CommentsPanel/CommentsDocker.cs
@@ -146,8 +146,6 @@ namespace CodeImp.DoomBuilder.CommentsPanel
 					cc.ReplaceElements(c.Value);
 				}
 			}
-			
-
 		}
 		
 		// This sets the timer to update the list very soon


### PR DESCRIPTION
Previously comments plugin was updating DataGridView at an obscene rate during opening the comments panel, or when loading a second map after a first one (as a part of cleanup routine), which bogged down the editor updates when comments quantity.
Changed how it handles it - now it suspends layout of grid, creates a separate list of DataGridViewRow's, references it in UpdateGroupList subfunction, then uses addrange for all the updated grid rows, and only then unsuspends layout and calls for an update on the view. 