### PR TITLE
fix: prevent Mono/X11 clipboard crash on paste (illegal byte sequence)

### DIFF
--- a/Source/Core/Editing/CopyPasteManager.cs
+++ b/Source/Core/Editing/CopyPasteManager.cs
@@ -305,8 +305,17 @@ namespace CodeImp.DoomBuilder.Editing
 				bool havepastedata = Clipboard.ContainsData(CLIPBOARD_DATA_FORMAT); //mxd
 				bool havedb2pastedata = Clipboard.ContainsData(CLIPBOARD_DATA_FORMAT_DB2); //mxd
 				#else
-				bool havepastedata = Clipboard.ContainsText() && Clipboard.GetText().Length > CLIPBOARD_DATA_FORMAT.Length && Clipboard.GetText().Substring(0, CLIPBOARD_DATA_FORMAT.Length) == CLIPBOARD_DATA_FORMAT;
+				bool havepastedata = false;
 				bool havedb2pastedata = false;
+				try
+				{
+					string clipText = Clipboard.GetText();
+					havepastedata = clipText.Length > CLIPBOARD_DATA_FORMAT.Length && clipText.StartsWith(CLIPBOARD_DATA_FORMAT);
+				}
+				catch(Exception)
+				{
+					havepastedata = false;
+				}
 				#endif
 				
 				// Anything to paste?


### PR DESCRIPTION
## Description

On Linux, pasting (Ctrl+V) in UDB crashes with `String conversion error: Illegal byte sequence` when the X11 clipboard contains binary data. This happens because Mono's `Clipboard.GetText()` → `Marshal.PtrToStringAnsi` throws on non-UTF8 bytes.

The crash is common when editing Doom 2 binary-format maps, because null-padded texture names from the X11 PRIMARY selection can't be decoded as ANSI text.

## Changes

**`CopyPasteManager.DoPasteSelection()`** — wraps the MONO_WINFORMS clipboard text check in a try-catch. Also optimizes from three `GetText()` calls down to one, using `StartsWith` instead of substring comparison.

## Testing

- Valid clipboard text (e.g. UDB's own base64 geometry data) → `GetText()` succeeds and paste works normally
- Garbled clipboard → exception caught, `havepastedata = false`, no crash

## Checklist

- [x] Compiled with `make` (C# + native library) — 0 errors
- [x] Only touches the `MONO_WINFORMS` preprocessor branch — Windows builds unaffected