### PR TITLE
Fix visual mode spin with absolute raw mouse input

### DIFF
--- a/Source/Native/RawMouse.cpp
+++ b/Source/Native/RawMouse.cpp
@@ -110,8 +110,20 @@ LRESULT RawMouse::OnMessage(INT message, WPARAM wparam, LPARAM lparam)
 				RAWINPUT* rawinput = (RAWINPUT*)buf.data();
 				if (rawinput->header.dwType == RIM_TYPEMOUSE)
 				{
-					x += rawinput->data.mouse.lLastX;
-					y += rawinput->data.mouse.lLastY;
+					if (rawinput->data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
+					{
+						// some sources report absolute coordinates (Wine, RDP, ...); use the delta
+						long ax = rawinput->data.mouse.lLastX;
+						long ay = rawinput->data.mouse.lLastY;
+						if (haveAbs) { x += (int)(ax - lastAbsX); y += (int)(ay - lastAbsY); }
+						lastAbsX = ax; lastAbsY = ay; haveAbs = true;
+					}
+					else
+					{
+						x += rawinput->data.mouse.lLastX;
+						y += rawinput->data.mouse.lLastY;
+						haveAbs = false;
+					}
 				}
 			}
 		}

--- a/Source/Native/RawMouse.h
+++ b/Source/Native/RawMouse.h
@@ -39,6 +39,10 @@ private:
 	HWND handle = 0;
 	int x = 0;
 	int y = 0;
+	// previous position for devices that report MOUSE_MOVE_ABSOLUTE
+	bool haveAbs = false;
+	long lastAbsX = 0;
+	long lastAbsY = 0;
 
 	friend class RawMouseWindowClass;
 };


### PR DESCRIPTION
Raw input isn't always relative — when the device reports `MOUSE_MOVE_ABSOLUTE`, `lLastX`/`lLastY` are absolute coordinates, not deltas. `OnMessage` accumulates them either way, so in absolute mode the visual mode camera gets a huge constant delta every frame and just spins / stares at the floor.

Check the flag and use the delta from the last position; relative mode is unchanged. Ran into it under Wine, but it can also happen over remote desktop and in some VMs.
